### PR TITLE
Only prepend path to filename if the user has not supplied a filepath

### DIFF
--- a/InchiGen.py
+++ b/InchiGen.py
@@ -162,9 +162,10 @@ def GetInchi(f):
 
     print("Get inchi f",f)
 
-    cwd = os.getcwd()
+    if "/" not in f:
+        f = os.getcwd() + '/' + f
 
-    m = Chem.MolFromMolFile(cwd + '/' + f ,removeHs = False)
+    m = Chem.MolFromMolFile(f, removeHs = False)
 
     idata = Chem.MolToInchiAndAuxInfo(m)
 


### PR DESCRIPTION
I was confused at first why supplying a full path to a file was not working. After diving into the source code, I discovered this block. This change ensures that if the user supplies a path to an input file, that path is used. If not, the program will still presume the file is in the current folder. 

This also fixes a bug in the GUI version, where picking a file outside of the DP-4 folder would cause the program to try loading /path/to/dp4-ai//path/supplied/by/qtfilepicker