### PR TITLE
Fix typo in string that reports source file to user.

### DIFF
--- a/InchiGen.py
+++ b/InchiGen.py
@@ -160,7 +160,7 @@ def RestoreNumsSDF(f, fold, AuxInfo):
 
 def GetInchi(f):
 
-    print("Get inchi f",f)
+    print("Getting inchi from file ",f)
 
     cwd = os.getcwd()
 


### PR DESCRIPTION
If I understood the output of this line correctly, I think the original represents a typo. 