### PR TITLE
Make GUI executable without calling Python

### DIFF
--- a/PyDP4_GUI.py
+++ b/PyDP4_GUI.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from PyQt5 import QtWidgets, QtCore, QtGui
 import time
 import os


### PR DESCRIPTION
I noticed that PyDP4.py was executable but PyDP4_GUI.py was not. This adds the executable flag to the file, which is invisible to source control. Additionally, the Python shebang has been placed at the top of the file so that it isn't necessary to call it via the Python interpreter. 