### PR TITLE
Fix reference-before-assignment bug in the case of a molecule with no diastereomers

### DIFF
--- a/InchiGen.py
+++ b/InchiGen.py
@@ -327,11 +327,10 @@ def GenDSInchis(inchi):
     for l in layers:
         if 't' in l:
             numds = 2**(len(l.translate({ord(i): None for i in 't,1234567890'}))-1)
-
-    try:
+    if numds == 0:
+        raise ValueError("No chiral carbon detected in the input molecule!")
+    else:
         print("Number of diastereomers to be generated: " + str(numds))
-    except UnboundLocalError as e:
-        raise ValueError("No chiral carbon present in the input molecule!") from e
 
     #find configuration sites (+ and -)
     bs = ilist.index('t')

--- a/InchiGen.py
+++ b/InchiGen.py
@@ -322,6 +322,7 @@ def GenDSInchis(inchi):
     resinchis = []
 
     #get the number of potential diastereomers
+    numds = 0
     layers = inchi.split('/')
     for l in layers:
         if 't' in l:


### PR DESCRIPTION
If you try to run this program on a molecule with no diastereomers, the program tries to print out a variable that has not yet been instantiated. That's because in the original version of this loop, it was conditional as to whether the variable would be instantiated at all. 

Let me know your opinion on what the default value of numds should be -- 0 or 1. 

I anticipate that there are farther-reaching implications of this change, so I'm trying to investigate further before saying 'this is ready to be committed'. 

Since if I understand DP-4 correctly it does not work on molecules with no stereocenters, it might be more elegant to notify the user of this instead of having it crash out. 

Specifically what led here was an attempt to see why a molecule with this InChI `InChI=1S/C22H24N2O3/c1-26-18-10-5-8-15(19(18)27-2)20-23-21(25)17-13-14-7-3-4-9-16(14)22(17)11-6-12-24(20)22/h3-5,7-10,17,20H,6,11-13H2,1-2H3,(H,23,25)` which should have 3 stereocenters doesn't appear to want to go through that function. 